### PR TITLE
Fix docstring in config loader

### DIFF
--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -230,7 +230,7 @@ def evaluate_ua_match(ref: str, pred: str, intent: str) -> float:
 
 
 def load_config(config_file: Union[Path, str]) -> List[Dict[str, Any]]:
-    """Load the confiufiguration for the test cases
+    """Load the configuration for the test cases.
 
     Args:
         config_file Union[Path, str]: Path to the config file


### PR DESCRIPTION
## Summary
- correct the typo in `load_config` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nltk')*

------
https://chatgpt.com/codex/tasks/task_e_68416773c424832abfa9a943ebee4a45